### PR TITLE
Add interface option

### DIFF
--- a/lib/artnet.js
+++ b/lib/artnet.js
@@ -8,17 +8,22 @@ var Artnet = function () {
 };
 
 
-Artnet.prototype.connect = function (host, port, universe, refresh) {
+Artnet.prototype.connect = function (host, port, universe, refresh, interf) {
 
     this.host =     host                    || '255.255.255.255';
     this.port =     port                    || 6454;
     this.universe = parseInt(universe, 10)  || 0;
     this.refresh =  refresh                 || 0;
+    this.interf =   interf                  || 0;
 
     this.header =   [65, 114, 116, 45, 78, 101, 116, 0, 0, 80, 0, 14, 0, 0, this.universe, 0, 2, 0];
     this.data =     Array.apply(null, new Array(512)).map(Number.prototype.valueOf, 0);
 
     this.socket = dgram.createSocket("udp4");
+
+    if(interf!=0){
+      this.socket.bind(port, interf);
+    }
 
     if (this.refresh >= 50) {
         this.interval = setInterval(function (_this) {


### PR DESCRIPTION
On computers with multiple (i.e. Wifi and Ethernet) interfaces, the
non-primary interface can be selected by IP.

Added a parameter for interface IP in connect()
