### PR TITLE
Fixed calculation of changed DMX values

### DIFF
--- a/lib/artnet.js
+++ b/lib/artnet.js
@@ -134,7 +134,7 @@ var Artnet = function (config) {
                 index = channel + i - 1;
                 if (typeof value[i] === 'number' && data[universe][index] !== value[i]) {
                     data[universe][index] = value[i];
-                    if ((i + 1) > dataChanged[universe]) dataChanged[universe] = i + 1;
+                    if ((index + 1) > dataChanged[universe]) dataChanged[universe] = index + 1;
                 }
             }
         } else {


### PR DESCRIPTION
This little bug leads to values are not sent correctly.
E.g. when calling `artnet.set(50, [255, null, 127]);`,`dataChanged[0]` should be equal to 52 but when using `i`, `dataChanged[0]` is equal to 3.
