### PR TITLE
add host setting

### DIFF
--- a/lib/artnet.js
+++ b/lib/artnet.js
@@ -159,6 +159,10 @@ var Artnet = function (config) {
         socket.close();
     };
 
+    this.setHost = function () {
+        host = arguments[0];
+    };
+
 
 };
 


### PR DESCRIPTION
Allows you to change the host setting after the options have been past. Super useful if your device changes it's ip address.
