### PR TITLE
Add setPort method

### DIFF
--- a/lib/artnet.js
+++ b/lib/artnet.js
@@ -20,10 +20,6 @@ var Artnet = function (config) {
 
     socket.on('error', err => this.emit('error', err));
 
-    if (config.iface) {
-        socket.bind(port, config.iface);
-    }
-
     // index of the following arrays is the universe
     var data =          [];     // the 512 dmx channels
     var interval =      [];     // the intervals for the 4sec refresh

--- a/lib/artnet.js
+++ b/lib/artnet.js
@@ -167,7 +167,9 @@ var Artnet = function (config) {
         host = h;
     };
 
-
+    this.setPort = function(p) {
+        port = p;
+    };
 };
 
 Artnet.prototype = Object.create(EventEmitter.prototype);


### PR DESCRIPTION
* removes the socket bind
* adds setPort method

We don't need the socket bind because it is only for incoming messages, outgoing messages always use all interfaces as far as i know.
With its removal we can add a setPort method because we don't access it in the setup phase any longer.