### PR TITLE
Add setPort method

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ This lib throttles the maximum send rate to ~40Hz. Unchanged data is refreshed e
   * refresh (millisecond interval for sending unchanged data to the Art-Net node. Default ```4000```)
   * iface (optional string IP address - bind udp socket to specific network interface)
   * sendAll (sends always the full DMX universe instead of only changed values. Default ```false```)
+  * broadcast (listen for artnet broadcasts. Default ```true```)
 
 
 ## Methods
@@ -75,6 +76,10 @@ Closes the connection and stops the send interval.
 
 Change the Art-Net hostname/address after initialization
 
+#### **setPort(** *number* **port** **)**
+
+Change the Art-Net port after initialization.
+Only works when broadcast is disabled.
 
 # Further Reading
 

--- a/lib/artnet.js
+++ b/lib/artnet.js
@@ -20,10 +20,6 @@ var Artnet = function (config) {
 
     socket.on('error', err => this.emit('error', err));
 
-    if (config.iface) {
-        socket.bind(port, config.iface);
-    }
-
     // index of the following arrays is the universe
     var data =          [];     // the 512 dmx channels
     var interval =      [];     // the intervals for the 4sec refresh

--- a/lib/artnet.js
+++ b/lib/artnet.js
@@ -167,7 +167,9 @@ var Artnet = function (config) {
         host = h;
     };
 
-
+    this.setPort = function(p) {
+        port = p;
+    };
 };
 
 Artnet.prototype = Object.create(EventEmitter.prototype);

--- a/lib/artnet.js
+++ b/lib/artnet.js
@@ -14,12 +14,17 @@ var Artnet = function (config) {
     var port =     parseInt(config.port)          || 6454;
     var refresh =  parseInt(config.refresh)       || 4000;
     var sendAll =  config.sendAll                 || false;
+    var broadcast = config.broadcast !== undefined ? config.broadcast : true;
 
     var socket = dgram.createSocket("udp4");
 
     socket.on('error', function (err) {
         that.emit('error', err);
     });
+
+    if (config.iface && broadcast) {
+        socket.bind(port, config.iface);
+    }
 
     // index of the following arrays is the universe
     var data =          [];     // the 512 dmx channels
@@ -169,7 +174,11 @@ var Artnet = function (config) {
     };
 
     this.setPort = function(p) {
-        port = p;
+        if (broadcast) {
+            throw new Error('Disable Broadcast for on the fly port changing');
+        }else {
+            port = p;
+        }
     };
 };
 


### PR DESCRIPTION
* removes the socket bind
* adds setPort method

We don't need the socket bind because it is only for incoming messages, outgoing messages always use all interfaces as far as i know.
With its removal we can add a setPort method because we don't access it in the setup phase any longer.

_New PR so I can move this code into its own branch_