### PR TITLE
clear send throttle timeouts on close

### DIFF
--- a/lib/artnet.js
+++ b/lib/artnet.js
@@ -163,8 +163,12 @@ var Artnet = function (config) {
     };
 
     this.close = function () {
-        for (var i = 0; i < interval.length; i++)
-        clearInterval(interval[i]);
+        for (var i = 0; i < interval.length; i++) {
+            clearInterval(interval[i]);
+        }
+        for (var i = 0; i < sendThrottle.length; i++) {
+            clearTimeout(sendThrottle[i]);
+        }
         socket.close();
     };
 


### PR DESCRIPTION
This fixes a bug where dgram throws a not running Error when closing the socket immediately after setting a value.

Code for reproduction:
```javascript
const artnet = require('./lib/artnet');

let conn = artnet({
    host: '127.0.0.1'
});

conn.set(0, 1, 255);
conn.set(0, 2, 255);

conn.close();
```

Thrown Error:
```
dgram.js:525
    throw new Error('Not running'); // error message from dgram_legacy.js
    ^

Error: Not running
    at Socket._healthCheck (dgram.js:525:11)
    at Socket.send (dgram.js:343:8)
    at Artnet.send (/Users/max/Documents/Code/artnet/lib/artnet.js:88:16)
    at Timeout._onTimeout (/Users/max/Documents/Code/artnet/lib/artnet.js:82:22)
    at ontimeout (timers.js:386:14)
    at tryOnTimeout (timers.js:250:5)
    at Timer.listOnTimeout (timers.js:214:5)
```

This PR closes all sendThrottle timeouts before closing the sockets