### PR TITLE
Added reuseAddr: true to dgram.createSocket

### DIFF
--- a/lib/artnet.js
+++ b/lib/artnet.js
@@ -17,7 +17,7 @@ var Artnet = function (config) {
     var refresh =  parseInt(config.refresh, 10)   || 4000;
     var sendAll =  config.sendAll                 || false;
 
-    var socket = dgram.createSocket({type:'udp4',reuseAddr:true});
+    var socket = dgram.createSocket({type: 'udp4', reuseAddr: true});
 
     socket.on('error', function (err) {
         that.emit('error', err);

--- a/lib/artnet.js
+++ b/lib/artnet.js
@@ -17,7 +17,7 @@ var Artnet = function (config) {
     var refresh =  parseInt(config.refresh, 10)   || 4000;
     var sendAll =  config.sendAll                 || false;
 
-    var socket = dgram.createSocket('udp4');
+    var socket = dgram.createSocket({type:'udp4',reuseAddr:true});
 
     socket.on('error', function (err) {
         that.emit('error', err);


### PR DESCRIPTION
Now it's possible to use the Artnet-Libary with another Artnet-enabled-Software running on the same device (Tested with DMXControl3)