### PR TITLE
Adds ArtTrigger Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,16 @@ you can omit the channel, it defaults to 1
 artnet.set([255, 127]);
 ```
 
+Additionally, you can send trigger macros to devices.
+
+```javascript
+// Send key 3, subkey 1 to all devices.
+artnet.trigger(1, 3);
+
+// Send key 2, subkey 71 (the letter 'G') to ArtNet Devices responding to 0x6A6B.
+artnet.trigger(27243, 71, 2);
+```
+
 This lib throttles the maximum send rate to ~40Hz. Unchanged data is refreshed every ~4s.
 
 ## Options
@@ -67,6 +77,20 @@ Defaults: universe = 0, channel = 1
 Callback is called with (error, response) params.
 If error and response are null data remained unchanged and therefore nothing has been sent.
 
+#### **trigger(** [ [ *uint15* **oem** , ] *uint9* **subkey** , ] *uint8* **key** [ , *function(err, res)* **callback** ] **)**
+
+Sends an ArtNet ArtTrigger packet. ArtTriggers are typically device specific and perform functions like starting and stopping shows.
+
+Every parameter except the `key` is optional.  If you supply an `oem`, you need to supply a `subkey` also.
+
+Defaults:
+
+* `oem` = `0xFFFF`
+* `subkey` = `null`
+
+Callback is called with `(error, response)` params.
+
+`trigger`s are NEVER throttled, as they are time sensitive. They are always sent immediately upon processing.
 
 #### **close( )**
 

--- a/lib/artnet.js
+++ b/lib/artnet.js
@@ -59,8 +59,8 @@ var Artnet = function (config) {
 
         // Payload is manufacturer specific
         var payload = Array.apply(null, new Array(512)).map(function () {
-                return null;
-            }, 0);
+            return null;
+        }, 0);
         // eslint-disable-next-line unicorn/no-new-buffer
         return new Buffer(header.concat(payload));
     };

--- a/lib/artnet.js
+++ b/lib/artnet.js
@@ -49,6 +49,28 @@ var Artnet = function (config) {
         }, refresh);
     };
 
+    // See http://www.artisticlicence.com/WebSiteMaster/User%20Guides/art-net.pdf page 40
+    var triggerPackage = function (oem, key, subkey) {
+        /* eslint-disable unicorn/number-literal-case */
+        var hOem = (oem >> 8) & 0xff;
+        var lOem = oem & 0xff;
+
+        var header = [65, 114, 116, 45, 78, 101, 116, 0, 0, 153, 0, 14, 0, 0, hOem, lOem, key, subkey];
+
+        // Payload is manufacturer specific
+        var payload = Array.apply(null, new Array(512)).map(function () {
+                return null;
+            }, 0);
+        // eslint-disable-next-line unicorn/no-new-buffer
+        return new Buffer(header.concat(payload));
+    };
+
+    // Triggers should always be sent, never throttled
+    this.sendTrigger = function (oem, key, subkey, callback) {
+        var buf = triggerPackage(oem, key, subkey);
+        socket.send(buf, 0, buf.length, port, host, callback);
+    };
+
     // See http://www.artisticlicence.com/WebSiteMaster/User%20Guides/art-net.pdf page 45
     var artdmxPackage = function (universe, length) {
         length = parseInt(length, 10) || 2;
@@ -180,6 +202,52 @@ var Artnet = function (config) {
         } else if (typeof callback === 'function') {
             callback(null, null);
         }
+
+        return true;
+    };
+
+    /* [ [ uint15 oem, ] uint9 subkey, ] uint8 key [, function callback ] */
+    this.trigger = function () {
+        var oem;
+        var subkey;
+        var key;
+        var callback;
+
+        if (arguments.length === 4) {
+            oem = arguments[0];
+            subkey = arguments[1];
+            key = arguments[2];
+            callback = arguments[3];
+        } else if (arguments.length === 3) {
+            if (typeof arguments[2] === 'function') {
+                subkey = arguments[0];
+                key = arguments[1];
+                callback = arguments[2];
+            } else {
+                oem = arguments[0];
+                subkey = arguments[1];
+                key = arguments[2];
+            }
+        } else if (arguments.length === 2) {
+            if (typeof arguments[1] === 'function') {
+                subkey = 1;
+                key = arguments[0];
+                callback = arguments[1];
+            } else {
+                subkey = arguments[0];
+                key = arguments[1];
+            }
+        } else if (arguments.length === 1) {
+            subkey = 0;
+            key = arguments[0];
+        } else {
+            return false;
+        }
+
+        oem = parseInt(oem, 10) || 65535; // Most devices respond to "0xFFFF", which is considered a triggered broadcast.
+        key = parseInt(key, 10) || 255;
+
+        that.sendTrigger(oem, key, subkey, callback);
 
         return true;
     };


### PR DESCRIPTION
Implements #19

The ArtTrigger packet is used to send trigger macros to the network. The
most common implementation involves a single controller broadcasting to
all other devices.

Please see page 41 of the referenced PDF for the packet definition of
the ArtTrigger OpCode.

https://www.artisticlicence.com/WebSiteMaster/User%20Guides/art-net.pdf

```.trigger([ [ uint15 oem, ] uint9 subkey, ] uint8 key [, function callback ]);```