### PR TITLE
fix #22

### DIFF
--- a/lib/artnet.js
+++ b/lib/artnet.js
@@ -23,7 +23,7 @@ var Artnet = function (config) {
         that.emit('error', err);
     });
 
-    if (config.iface && (host === '255.255.255.255')) {
+    if (config.iface) {
         socket.bind(port, config.iface, function () {
             socket.setBroadcast(true);
         });

--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "camo-purge": "latest",
-    "xo": "latest"
+    "camo-purge": "1.0.2",
+    "xo": "0.17.0"
   },
   "scripts": {
     "test": "camo-purge ; xo --space 4 --no-esnext --ignore test.js"


### PR DESCRIPTION
Fix the bug which prevents a non-broadcast `host` from being used alongside a custom `iface` (#22)